### PR TITLE
Docker + TLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4"
+actix-web = { version = "4", features = ["openssl"] }
+openssl = { version = "0.10", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ EXPOSE 8080
 WORKDIR /app
 COPY . .
 
+# TODO: Remove - Temporary self-signed cert for testing
 RUN openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost'
 
 RUN cargo install --path .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.69.0
+
+EXPOSE 8080
+
+WORKDIR /app
+COPY . .
+
+RUN openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost'
+
+RUN cargo install --path .
+CMD ["effward-dev"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # effward-dev
 Code for effward.dev site
+
+## Prerequisites
+- Docker/Docker Desktop
+- 
+
+## Build
+Build with:
+```
+docker build -t effward-dev .
+```
+
+## Run
+Run with:
+```
+docker run -it --rm -p 8080:8080 effward-dev
+```
+
+## Deploy
+TBD

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 Code for effward.dev site
 
 ## Prerequisites
+- Rust
 - Docker/Docker Desktop
-- 
+- FlyCTL
 
 ## Build
 Build with:
-```
+```sh
 docker build -t effward-dev .
 ```
 
 ## Run
 Run with:
-```
+```sh
 docker run -it --rm -p 8080:8080 effward-dev
 ```
 


### PR DESCRIPTION
OpenSSL was having issues with Windows (or vice versa), so switched to building/running in docker.

Added `openssl` dependency, and actix startup code to enable TLS.

Added basic logging to request handlers.

Added some details to README about build/run.