### PR TITLE
Switch from Planetscale to Aiven for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cargo fmt
 
 ## Environment Variables
 Set the following environment variables:
-- DATABASE_URL (PlanetScale)
+- DATABASE_URL (Aiven shared-sql instance)
 - HMAC_KEY (Generate 512 bit key [here](https://generate-random.org/api-key-generator/512-bit/mixed-numbers))
 - REDIS_URI (redis://127.0.0.1:6379)
 

--- a/src/routes/error/not_found/get.rs
+++ b/src/routes/error/not_found/get.rs
@@ -51,7 +51,7 @@ pub fn render_not_found<B>(res: ServiceResponse<B>) -> Result<ErrorHandlerRespon
 
 fn build_response(tera: &Tera, user_context: &mut UserContext) -> HttpResponse {
     let mut missing_type = DEFAULT_MISSING_TYPE;
-    if user_context.flash_messages.is_empty() {
+    if !user_context.flash_messages.is_empty() {
         missing_type = &user_context.flash_messages[0];
     }
 


### PR DESCRIPTION
The real change is switching the GHA secret to the new Aiven MySQL connection string (and also using it locally in the `DATABASE_URL` env var for testing.

This readme change is to keep things up-to-date, and to trigger a redeploy of the site (which will use the new connection string from GHA).